### PR TITLE
Resolved texture memory and depth buffer issues.

### DIFF
--- a/Sources/Core/Sources/Render/Renderer/WorldRenderer.swift
+++ b/Sources/Core/Sources/Render/Renderer/WorldRenderer.swift
@@ -480,6 +480,9 @@ class WorldRenderer {
     
     let transparentAndOpaqueRenderDescriptor = renderPassDescriptor
     transparentAndOpaqueRenderDescriptor.colorAttachments[0].loadAction = .clear
+    // Explicitly tell that depth buffer should be stored.
+    transparentAndOpaqueRenderDescriptor.depthAttachment.storeAction = .store
+      
     let translucentRenderDescriptor = MTLRenderPassDescriptor()
     translucentRenderDescriptor.colorAttachments[0].texture = drawableTexture
     translucentRenderDescriptor.colorAttachments[0].loadAction = .load

--- a/Sources/Core/Sources/Resources/Texture/Texture.swift
+++ b/Sources/Core/Sources/Resources/Texture/Texture.swift
@@ -1,4 +1,5 @@
 import Foundation
+import ColorSync
 
 public enum TextureError: LocalizedError {
   /// The texture's height must be a multiple of the width.

--- a/Sources/Core/Sources/Resources/Texture/TexturePalette.swift
+++ b/Sources/Core/Sources/Resources/Texture/TexturePalette.swift
@@ -114,11 +114,12 @@ public struct TexturePalette {
   /// Returns a metal texture array on the given device, containing the first frame of each texture.
   public func createTextureArray(device: MTLDevice, animationState: TexturePaletteAnimationState, commandQueue: MTLCommandQueue) throws -> MTLTexture {
     let textureDescriptor = MTLTextureDescriptor()
-    textureDescriptor.textureType = .type2DArray
-    textureDescriptor.arrayLength = textures.count
-    textureDescriptor.pixelFormat = .bgra8Unorm
     textureDescriptor.width = width
     textureDescriptor.height = width
+    textureDescriptor.storageMode = .shared
+    textureDescriptor.pixelFormat = .bgra8Unorm
+    textureDescriptor.textureType = .type2DArray
+    textureDescriptor.arrayLength = textures.count
     textureDescriptor.mipmapLevelCount = 1 + Int(log2(Double(width)).rounded(.down))
 //    textureDescriptor.resourceOptions = [.]
     


### PR DESCRIPTION
# Description

Changes texture array storage mode from default `Managed` to `Shared`. Data is updated by CPU, and accessed by GPU, preserving two separate copies of the resource is not necessary. Yields possible performance gains for discrete memory models.

Resolves issues on M1 machines where translucent blocks are rendered on top of all other geometry (#22). Caused by lack of explicit setting for `depthAttachment.storeAction` which defaults to `.dontCare`.
This impacted TBDR GPU's where buffer was cleared between two passes. Change shouldn't affect IMR GPU's.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation comments
- [x] My changes generate no new warnings