### PR TITLE
Set storage mode according to the memory model of the GPU.

### DIFF
--- a/Sources/Core/Sources/Resources/Texture/TexturePalette.swift
+++ b/Sources/Core/Sources/Resources/Texture/TexturePalette.swift
@@ -116,10 +116,10 @@ public struct TexturePalette {
     let textureDescriptor = MTLTextureDescriptor()
     textureDescriptor.width = width
     textureDescriptor.height = width
-    textureDescriptor.storageMode = .managed
     textureDescriptor.pixelFormat = .bgra8Unorm
     textureDescriptor.textureType = .type2DArray
     textureDescriptor.arrayLength = textures.count
+    textureDescriptor.storageMode = (device.hasUnifiedMemory) ? .shared : .managed
     textureDescriptor.mipmapLevelCount = 1 + Int(log2(Double(width)).rounded(.down))
 //    textureDescriptor.resourceOptions = [.]
     


### PR DESCRIPTION
# Description

Devices with Unified memory model can utilise `.Shared` storage setting.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation comments
- [x] My changes generate no new warnings
