### PR TITLE
Merge world rendering encoders into one, unified encoder.

### DIFF
--- a/Sources/Core/Sources/Render/Mesh/ChunkSectionMesh.swift
+++ b/Sources/Core/Sources/Render/Mesh/ChunkSectionMesh.swift
@@ -25,24 +25,33 @@ public struct ChunkSectionMesh {
     translucentMesh.clear()
   }
     
-  /// Encode the render commands for this chunk section.
+  /// Encode the render commands for transparent and opaque mesh of this chunk section.
   /// - Parameters:
-  ///   - position: Position the mesh is viewed from. Used for sorting.
-  ///   - renderTranslucent: Defines whether translucent or transparent and opaque mesh is rendered.
-  ///   - worldRenderEncoder: Encoder for rendering geometry.
+  ///   - renderEncoder: Encoder for rendering geometry.
   ///   - device: The device to use.
   ///   - commandQueue: The command queue to use for creating buffers.
-  public mutating func render(
-    viewedFrom position: SIMD3<Float>,
-    renderTranslucent: Bool,
-    worldRenderEncoder: MTLRenderCommandEncoder,
+  public mutating func renderTransparentOpaque(
+    renderEncoder: MTLRenderCommandEncoder,
     device: MTLDevice,
     commandQueue: MTLCommandQueue
   ) throws {
-      if renderTranslucent {
-        try translucentMesh.render(viewedFrom: position, sort: renderTranslucent, encoder: worldRenderEncoder, device: device, commandQueue: commandQueue)
-      } else {
-        try transparentAndOpaqueMesh.render(into: worldRenderEncoder, with: device, commandQueue: commandQueue)
-      }
+    try transparentAndOpaqueMesh.render(into: renderEncoder, with: device, commandQueue: commandQueue)
+  }
+    
+  /// Encode the render commands for translucent mesh of this chunk section.
+  /// - Parameters:
+  ///   - position: Position the mesh is viewed from. Used for sorting.
+  ///   - sortTranslucent: Indicates whether sorting should be enabled for translucent mesh rendering.
+  ///   - renderEncoder: Encoder for rendering geometry.
+  ///   - device: The device to use.
+  ///   - commandQueue: The command queue to use for creating buffers.
+  public mutating func renderTranslucent(
+    viewedFrom position: SIMD3<Float>,
+    sortTranslucent: Bool,
+    renderEncoder: MTLRenderCommandEncoder,
+    device: MTLDevice,
+    commandQueue: MTLCommandQueue
+  ) throws {
+    try translucentMesh.render(viewedFrom: position, sort: sortTranslucent, encoder: renderEncoder, device: device, commandQueue: commandQueue)
   }
 }

--- a/Sources/Core/Sources/Render/Mesh/ChunkSectionMesh.swift
+++ b/Sources/Core/Sources/Render/Mesh/ChunkSectionMesh.swift
@@ -24,24 +24,25 @@ public struct ChunkSectionMesh {
     transparentAndOpaqueMesh.clearGeometry()
     translucentMesh.clear()
   }
-  
+    
   /// Encode the render commands for this chunk section.
   /// - Parameters:
   ///   - position: Position the mesh is viewed from. Used for sorting.
-  ///   - sortTranslucent: Whether the translucent mesh should be sorted or not.
-  ///   - transparentAndOpaqueEncoder: Encoder for rendering transparent and opaque geometry.
-  ///   - translucentEncoder: Encoder for rendering translucent geometry.
+  ///   - renderTranslucent: Defines whether translucent or transparent and opaque mesh is rendered.
+  ///   - worldRenderEncoder: Encoder for rendering geometry.
   ///   - device: The device to use.
   ///   - commandQueue: The command queue to use for creating buffers.
   public mutating func render(
     viewedFrom position: SIMD3<Float>,
-    sortTranslucent: Bool,
-    transparentAndOpaqueEncoder: MTLRenderCommandEncoder,
-    translucentEncoder: MTLRenderCommandEncoder,
+    renderTranslucent: Bool,
+    worldRenderEncoder: MTLRenderCommandEncoder,
     device: MTLDevice,
     commandQueue: MTLCommandQueue
   ) throws {
-    try transparentAndOpaqueMesh.render(into: transparentAndOpaqueEncoder, with: device, commandQueue: commandQueue)
-    try translucentMesh.render(viewedFrom: position, sort: sortTranslucent, encoder: translucentEncoder, device: device, commandQueue: commandQueue)
+      if renderTranslucent {
+        try translucentMesh.render(viewedFrom: position, sort: renderTranslucent, encoder: worldRenderEncoder, device: device, commandQueue: commandQueue)
+      } else {
+        try transparentAndOpaqueMesh.render(into: worldRenderEncoder, with: device, commandQueue: commandQueue)
+      }
   }
 }

--- a/Sources/Core/Sources/Render/RenderCoordinator.swift
+++ b/Sources/Core/Sources/Render/RenderCoordinator.swift
@@ -62,8 +62,7 @@ public class RenderCoordinator: NSObject, RenderCoordinatorProtocol, MTKViewDele
     
     updateCamera(client.game.player, view)
     
-    guard let worldRenderCommandBuffer = commandQueue.makeCommandBuffer()
-    else {
+    guard let commandBuffer = commandQueue.makeCommandBuffer() else {
       log.warning("Failed to create render command buffers")
       return
     }
@@ -72,7 +71,7 @@ public class RenderCoordinator: NSObject, RenderCoordinatorProtocol, MTKViewDele
     worldRenderer.draw(
       device: device,
       view: view,
-      worldRenderCommandBuffer: worldRenderCommandBuffer,
+      renderCommandBuffer: commandBuffer,
       camera: camera,
       commandQueue: commandQueue)
     stopwatch.stopMeasurement("world renderer")
@@ -82,8 +81,8 @@ public class RenderCoordinator: NSObject, RenderCoordinatorProtocol, MTKViewDele
       return
     }
     
-    worldRenderCommandBuffer.present(drawable)
-    worldRenderCommandBuffer.commit()
+    commandBuffer.present(drawable)
+    commandBuffer.commit()
     
     logFrame()
     stopwatch.stopMeasurement("whole frame")

--- a/Sources/Core/Sources/Render/RenderCoordinator.swift
+++ b/Sources/Core/Sources/Render/RenderCoordinator.swift
@@ -62,9 +62,7 @@ public class RenderCoordinator: NSObject, RenderCoordinatorProtocol, MTKViewDele
     
     updateCamera(client.game.player, view)
     
-    guard
-      let transparentAndOpaqueCommandBuffer = commandQueue.makeCommandBuffer(),
-      let translucentCommandBuffer = commandQueue.makeCommandBuffer()
+    guard let worldRenderCommandBuffer = commandQueue.makeCommandBuffer()
     else {
       log.warning("Failed to create render command buffers")
       return
@@ -74,8 +72,7 @@ public class RenderCoordinator: NSObject, RenderCoordinatorProtocol, MTKViewDele
     worldRenderer.draw(
       device: device,
       view: view,
-      transparentAndOpaqueCommandBuffer: transparentAndOpaqueCommandBuffer,
-      translucentCommandBuffer: translucentCommandBuffer,
+      worldRenderCommandBuffer: worldRenderCommandBuffer,
       camera: camera,
       commandQueue: commandQueue)
     stopwatch.stopMeasurement("world renderer")
@@ -85,9 +82,8 @@ public class RenderCoordinator: NSObject, RenderCoordinatorProtocol, MTKViewDele
       return
     }
     
-    transparentAndOpaqueCommandBuffer.commit()
-    translucentCommandBuffer.present(drawable)
-    translucentCommandBuffer.commit()
+    worldRenderCommandBuffer.present(drawable)
+    worldRenderCommandBuffer.commit()
     
     logFrame()
     stopwatch.stopMeasurement("whole frame")

--- a/Sources/Core/Sources/Render/Renderer/ChunkRenderer.swift
+++ b/Sources/Core/Sources/Render/Renderer/ChunkRenderer.swift
@@ -144,7 +144,7 @@ class ChunkRenderer {
   }
   
   /// Renders this renderer's chunk
-  func render(transparentAndOpaqueEncoder: MTLRenderCommandEncoder, translucentEncoder: MTLRenderCommandEncoder, with device: MTLDevice, and camera: Camera, commandQueue: MTLCommandQueue) {
+  func render(worldRenderEncoder: MTLRenderCommandEncoder, with device: MTLDevice, and camera: Camera, renderTranslucent: Bool, commandQueue: MTLCommandQueue) {
     sectionMeshesAccessQueue.sync {
       sectionMeshes.mutatingEach { sectionY, mesh in
         // Don't need to check if mesh is empty because the mesh builder never returns empty meshes
@@ -157,9 +157,8 @@ class ChunkRenderer {
         do {
           try mesh.render(
             viewedFrom: camera.position,
-            sortTranslucent: true,
-            transparentAndOpaqueEncoder: transparentAndOpaqueEncoder,
-            translucentEncoder: translucentEncoder,
+            renderTranslucent: renderTranslucent,
+            worldRenderEncoder: worldRenderEncoder,
             device: device,
             commandQueue: commandQueue)
         } catch {

--- a/Sources/Core/Sources/Render/Renderer/Shader/ChunkShaders.metal
+++ b/Sources/Core/Sources/Render/Renderer/Shader/ChunkShaders.metal
@@ -55,6 +55,10 @@ fragment float4 chunkFragmentShader(RasteriserData in [[stage_in]],
   if (in.isTransparent && color.w < 0.33) {
     discard_fragment();
   }
+    
+  if (in.isTransparent) {
+      color.w = 1;
+  }
   
   return color;
 }

--- a/Sources/Core/Sources/Render/Renderer/Shader/ChunkShaders.metal
+++ b/Sources/Core/Sources/Render/Renderer/Shader/ChunkShaders.metal
@@ -57,7 +57,7 @@ fragment float4 chunkFragmentShader(RasteriserData in [[stage_in]],
   }
     
   if (in.isTransparent) {
-      color.w = 1;
+    color.w = 1;
   }
   
   return color;

--- a/Sources/Core/Sources/Resources/Texture/Texture.swift
+++ b/Sources/Core/Sources/Resources/Texture/Texture.swift
@@ -182,6 +182,7 @@ public struct Texture {
     
   /// Sets the alpha components of the texutre to a specified value. Alpha value is bound to a range (0...255 inclusive).
   public mutating func setAlpha(_ alpha: UInt8) {
+    let clampAlpha = min(max(alpha, 0), 255)
     for x in 0..<width {
       for y in 0..<height {
         let pixel = getPixel(atX: x, y: y)
@@ -189,7 +190,7 @@ public struct Texture {
           r: UInt8(pixel.r),
           g: UInt8(pixel.g),
           b: UInt8(pixel.b),
-          a: UInt8(min(max(alpha, 0), 255)))
+          a: UInt8(clampAlpha))
         setPixel(atX: x, y: y, to: newPixel)
       }
     }

--- a/Sources/Core/Sources/Resources/Texture/Texture.swift
+++ b/Sources/Core/Sources/Resources/Texture/Texture.swift
@@ -179,6 +179,21 @@ public struct Texture {
     bytes[index + 2] = pixel.r
     bytes[index + 3] = pixel.a
   }
+    
+  /// Sets the alpha components of the texutre to a specified value. Alpha value is bound to a range (0...255 inclusive).
+  public mutating func setAlpha(_ alpha: UInt8) {
+    for x in 0..<width {
+      for y in 0..<height {
+        let pixel = getPixel(atX: x, y: y)
+        let newPixel = Pixel(
+          r: UInt8(pixel.r),
+          g: UInt8(pixel.g),
+          b: UInt8(pixel.b),
+          a: UInt8(min(max(alpha, 0), 255)))
+        setPixel(atX: x, y: y, to: newPixel)
+      }
+    }
+  }
   
   /// Divides the rgb components by the alpha component to unpremultiply the alpha.
   public mutating func unpremultiply() {

--- a/Sources/Core/Sources/Resources/Texture/TexturePalette.swift
+++ b/Sources/Core/Sources/Resources/Texture/TexturePalette.swift
@@ -91,7 +91,9 @@ public struct TexturePalette {
           scaledToWidth: maxWidth,
           checkDimensions: true)
         
-        if texture.type != .opaque {
+        if texture.type == .opaque {
+          texture.setAlpha(255)
+        } else {
           // Change the color of transparent pixels to make mipmaps look more natural
           texture.fixTransparentPixels()
         }


### PR DESCRIPTION
# Description

This PR focuses on merging two separate rendering encoders for two types of `Mesh`:
- Opaque and transparent
- Translucent

For blending to work appropriately, correct order of encoding is preserved. Firstly, opaque and transparent meshes are encoded, translucent meshes are encoded afterwards with sorting enabled (distance-wise).

Switching to this approach introduced issues with some textures and their type. These issues are resolved by introducing new method `setAlpha(_:)` and changes to the fragment shader, which deal with alpha channel discrepancies.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation comments
- [x] My changes generate no new warnings
