### PR TITLE
Create a CustomJSONDecoder wrapper, and replace swift-concurrency with swift-atomics

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -11,6 +11,15 @@
         }
       },
       {
+        "package": "CryptoSwift",
+        "repositoryURL": "https://github.com/krzyzanowskim/CryptoSwift.git",
+        "state": {
+          "branch": null,
+          "revision": "5669f222e46c8134fb1f399c745fa6882b43532e",
+          "version": "1.3.8"
+        }
+      },
+      {
         "package": "DeltaLogger",
         "repositoryURL": "https://github.com/stackotter/delta-logger",
         "state": {

--- a/Package.resolved
+++ b/Package.resolved
@@ -83,21 +83,21 @@
         }
       },
       {
+        "package": "swift-atomics",
+        "repositoryURL": "https://github.com/apple/swift-atomics.git",
+        "state": {
+          "branch": null,
+          "revision": "919eb1d83e02121cdb434c7bfc1f0c66ef17febe",
+          "version": "1.0.2"
+        }
+      },
+      {
         "package": "swift-collections",
         "repositoryURL": "https://github.com/apple/swift-collections.git",
         "state": {
           "branch": null,
           "revision": "9d8719c8bebdc79740b6969c912ac706eb721d7a",
           "version": "0.0.7"
-        }
-      },
-      {
-        "package": "Concurrency",
-        "repositoryURL": "https://github.com/uber/swift-concurrency.git",
-        "state": {
-          "branch": null,
-          "revision": "e29e42c41c47c82ec32d3a2b2695719c32415ca9",
-          "version": "0.7.1"
         }
       },
       {

--- a/Sources/Client/Storage/ConfigManager.swift
+++ b/Sources/Client/Storage/ConfigManager.swift
@@ -57,7 +57,7 @@ public final class ConfigManager {
     // Read the current config from the config file
     do {
       let data = try Data(contentsOf: configFile)
-      _config = try ZippyJSONDecoder().decode(Config.self, from: data)
+      _config = try CustomJSONDecoder().decode(Config.self, from: data)
     } catch {
       // Existing config is corrupted, overwrite it with defaults
       log.error("Invalid config.json, overwriting with defaults")

--- a/Sources/Client/Util/Updater.swift
+++ b/Sources/Client/Util/Updater.swift
@@ -184,7 +184,7 @@ public final class Updater: ObservableObject {
   ///
   /// - Returns: A download URL and a version string
   private static func getLatestStableDownloadURL() throws -> (URL, String) {
-    let decoder = ZippyJSONDecoder()
+    let decoder = CustomJSONDecoder()
     decoder.keyDecodingStrategy = .convertFromSnakeCase
 
     let apiURL = URL(string: "https://api.github.com/repos/stackotter/delta-client/releases")!
@@ -223,7 +223,7 @@ public final class Updater: ObservableObject {
     let url = URL(string: "https://api.github.com/repos/stackotter/delta-client/branches")!
     do {
       let data = try Data(contentsOf: url)
-      let response = try ZippyJSONDecoder().decode([GitHubBranch].self, from: data)
+      let response = try CustomJSONDecoder().decode([GitHubBranch].self, from: data)
       return response
     } catch {
       throw UpdateError.failedToGetBranches(error)

--- a/Sources/Client/Util/Updater.swift
+++ b/Sources/Client/Util/Updater.swift
@@ -184,7 +184,7 @@ public final class Updater: ObservableObject {
   ///
   /// - Returns: A download URL and a version string
   private static func getLatestStableDownloadURL() throws -> (URL, String) {
-    let decoder = CustomJSONDecoder()
+    var decoder = CustomJSONDecoder()
     decoder.keyDecodingStrategy = .convertFromSnakeCase
 
     let apiURL = URL(string: "https://api.github.com/repos/stackotter/delta-client/releases")!

--- a/Sources/Core/Package.swift
+++ b/Sources/Core/Package.swift
@@ -9,7 +9,7 @@ var dependencies: [Package.Dependency] = [
   .package(name: "NioDNS", url: "https://github.com/OpenKitten/NioDNS", from: "1.0.2"),
   .package(name: "SwiftProtobuf", url: "https://github.com/apple/swift-protobuf.git", from: "1.6.0"),
   .package(name: "swift-collections", url: "https://github.com/apple/swift-collections.git", from: "0.0.7"),
-  .package(name: "Atomics", url: "https://github.com/apple/swift-atomics.git", from: "1.0.2"),
+  .package(name: "swift-atomics", url: "https://github.com/apple/swift-atomics.git", from: "1.0.2"),
   .package(name: "FirebladeECS", url: "https://github.com/stackotter/ecs.git", .branch("master")),
   .package(name: "ZippyJSON", url: "https://github.com/michaeleisel/ZippyJSON", from: "1.2.4"),
   .package(url: "https://github.com/pointfreeco/swift-parsing", .exact("0.8.0"))
@@ -37,8 +37,8 @@ let package = Package(
         "IDZSwiftCommonCrypto",
         "NioDNS",
         "SwiftProtobuf",
-        "Atomics",
         "FirebladeECS",
+        .product(name: "Atomics", package: "swift-atomics"),
         .product(name: "ZippyJSON", package: "ZippyJSON", condition: .when(platforms: [.macOS, .iOS, .tvOS])),
         .product(name: "Parsing", package: "swift-parsing"),
         .product(name: "Collections", package: "swift-collections"),

--- a/Sources/Core/Package.swift
+++ b/Sources/Core/Package.swift
@@ -9,7 +9,7 @@ var dependencies: [Package.Dependency] = [
   .package(name: "NioDNS", url: "https://github.com/OpenKitten/NioDNS", from: "1.0.2"),
   .package(name: "SwiftProtobuf", url: "https://github.com/apple/swift-protobuf.git", from: "1.6.0"),
   .package(name: "swift-collections", url: "https://github.com/apple/swift-collections.git", from: "0.0.7"),
-  .package(name: "Concurrency", url: "https://github.com/uber/swift-concurrency.git", from: "0.7.1"),
+  .package(name: "Atomics", url: "https://github.com/apple/swift-atomics.git", from: "1.0.2"),
   .package(name: "FirebladeECS", url: "https://github.com/stackotter/ecs.git", .branch("master")),
   .package(name: "ZippyJSON", url: "https://github.com/michaeleisel/ZippyJSON", from: "1.2.4"),
   .package(url: "https://github.com/pointfreeco/swift-parsing", .exact("0.8.0"))
@@ -37,7 +37,7 @@ let package = Package(
         "IDZSwiftCommonCrypto",
         "NioDNS",
         "SwiftProtobuf",
-        "Concurrency",
+        "Atomics",
         "FirebladeECS",
         .product(name: "ZippyJSON", package: "ZippyJSON", condition: .when(platforms: [.macOS, .iOS, .tvOS])),
         .product(name: "Parsing", package: "swift-parsing"),

--- a/Sources/Core/Package.swift
+++ b/Sources/Core/Package.swift
@@ -39,7 +39,7 @@ let package = Package(
         "SwiftProtobuf",
         "Concurrency",
         "FirebladeECS",
-        "ZippyJSON",
+        .product(name: "ZippyJSON", package: "ZippyJSON", condition: .when(platforms: [.macOS, .iOS, .tvOS])),
         .product(name: "Parsing", package: "swift-parsing"),
         .product(name: "Collections", package: "swift-collections"),
         .product(name: "OrderedCollections", package: "swift-collections")

--- a/Sources/Core/Sources/Account/Microsoft/MicrosoftAPI.swift
+++ b/Sources/Core/Sources/Account/Microsoft/MicrosoftAPI.swift
@@ -334,7 +334,7 @@ public enum MicrosoftAPI {
   /// - Returns: The decoded response.
   private static func decodeResponse<Response: Decodable>(_ data: Data) throws -> Response {
     do {
-      return try ZippyJSONDecoder().decode(Response.self, from: data)
+      return try CustomJSONDecoder().decode(Response.self, from: data)
     } catch {
       throw MicrosoftAPIError.failedToDeserializeResponse(error, String(data: data, encoding: .utf8) ?? "")
     }

--- a/Sources/Core/Sources/Account/Mojang/MojangAPI.swift
+++ b/Sources/Core/Sources/Account/Mojang/MojangAPI.swift
@@ -32,7 +32,7 @@ public enum MojangAPI {
     
     let (_, data) = try await RequestUtil.performJSONRequest(url: authenticationURL, body: payload, method: .post)
     
-    guard let response = try? ZippyJSONDecoder().decode(MojangAuthenticationResponse.self, from: data) else {
+    guard let response = try? CustomJSONDecoder().decode(MojangAuthenticationResponse.self, from: data) else {
       throw MojangAPIError.failedToDeserializeResponse(String(data: data, encoding: .utf8) ?? "")
     }
     
@@ -82,7 +82,7 @@ public enum MojangAPI {
     
     let (_, data) = try await RequestUtil.performJSONRequest(url: refreshURL, body: payload, method: .post)
     
-    guard let response = try? ZippyJSONDecoder().decode(MojangRefreshTokenResponse.self, from: data) else {
+    guard let response = try? CustomJSONDecoder().decode(MojangRefreshTokenResponse.self, from: data) else {
       throw MojangAPIError.failedToDeserializeResponse(String(data: data, encoding: .utf8) ?? "")
     }
     

--- a/Sources/Core/Sources/Cache/Registry/JSONCachableRegistry.swift
+++ b/Sources/Core/Sources/Cache/Registry/JSONCachableRegistry.swift
@@ -24,7 +24,7 @@ public extension JSONCachableRegistry {
   static func loadCached(from cacheDirectory: URL) throws -> Self {
     do {
       let data = try Data(contentsOf: cacheDirectory.appendingPathComponent(getCacheFileName()))
-      return try ZippyJSONDecoder().decode(Self.self, from: data)
+      return try CustomJSONDecoder().decode(Self.self, from: data)
     } catch {
       throw JSONCachableRegistryError.failedToLoadFromCache(Self.self, error)
     }

--- a/Sources/Core/Sources/Plugin/PluginEnvironment.swift
+++ b/Sources/Core/Sources/Plugin/PluginEnvironment.swift
@@ -138,7 +138,7 @@ public class PluginEnvironment: ObservableObject {
   public func loadPluginManifest(_ pluginBundle: URL) throws -> PluginManifest {
     do {
       let contents = try Data(contentsOf: pluginBundle.appendingPathComponent("manifest.json"))
-      return try ZippyJSONDecoder().decode(PluginManifest.self, from: contents)
+      return try CustomJSONDecoder().decode(PluginManifest.self, from: contents)
     } catch {
       throw PluginLoadingError.invalidManifest(error)
     }

--- a/Sources/Core/Sources/Registry/Pixlyzer/PixlyzerFormatter.swift
+++ b/Sources/Core/Sources/Registry/Pixlyzer/PixlyzerFormatter.swift
@@ -247,7 +247,7 @@ public enum PixlyzerFormatter {
     let contents = try Data(contentsOf: url)
 
     if useZippyJSON {
-      let decoder = ZippyJSONDecoder()
+      let decoder = CustomJSONDecoder()
       if convertSnakeCase {
         decoder.keyDecodingStrategy = .convertFromSnakeCase
       }

--- a/Sources/Core/Sources/Registry/Pixlyzer/PixlyzerFormatter.swift
+++ b/Sources/Core/Sources/Registry/Pixlyzer/PixlyzerFormatter.swift
@@ -247,7 +247,7 @@ public enum PixlyzerFormatter {
     let contents = try Data(contentsOf: url)
 
     if useZippyJSON {
-      let decoder = CustomJSONDecoder()
+      var decoder = CustomJSONDecoder()
       if convertSnakeCase {
         decoder.keyDecodingStrategy = .convertFromSnakeCase
       }

--- a/Sources/Core/Sources/Render/World/WorldMeshWorker.swift
+++ b/Sources/Core/Sources/Render/World/WorldMeshWorker.swift
@@ -78,7 +78,7 @@ public class WorldMeshWorker {
       return
     }
 
-    _ = executingThreadsCount.wrappingIncrement(ordering: .relaxed)
+    executingThreadsCount.wrappingIncrement(ordering: .relaxed)
 
     executionQueue.async {
       while true {

--- a/Sources/Core/Sources/Render/World/WorldMeshWorker.swift
+++ b/Sources/Core/Sources/Render/World/WorldMeshWorker.swift
@@ -1,5 +1,5 @@
 import Foundation
-import Concurrency
+import Atomics
 import Metal
 
 /// A multi-threaded worker that creates and updates the world's meshes. Completely threadsafe.
@@ -29,7 +29,7 @@ public class WorldMeshWorker {
   /// Serial dispatch queue for executing jobs on.
   private var executionQueue = DispatchQueue(label: "dev.stackotter.delta-client.WorldMeshWorker", attributes: [.concurrent])
   /// Whether the execution loop is currently running or not.
-  private var executingThreadsCount = AtomicInt(initialValue: 0)
+  private var executingThreadsCount = ManagedAtomic<Int>(0)
   /// The maximum number of execution loops allowed to run at once (for performance reasons).
   private let maxExecutingThreadsCount = 1 // TODO: Scale max threads and executionQueue qos with size of job queue
 

--- a/Sources/Core/Sources/Resources/Model/Block/JSON/JSONBlockModel.swift
+++ b/Sources/Core/Sources/Resources/Model/Block/JSON/JSONBlockModel.swift
@@ -84,7 +84,7 @@ extension JSONBlockModel {
     // swiftlint:enable force_unwrapping
 
     // Load JSON
-    let models: [String: JSONBlockModel] = try ZippyJSONDecoder().decode([String: JSONBlockModel].self, from: json)
+    let models: [String: JSONBlockModel] = try CustomJSONDecoder().decode([String: JSONBlockModel].self, from: json)
 
     // Convert from [String: JSONBlockModel] to [Identifier: JSONBlockModel]
     var identifiedModels: [Identifier: JSONBlockModel] = [:]

--- a/Sources/Core/Sources/Resources/ResourcePack.swift
+++ b/Sources/Core/Sources/Resources/ResourcePack.swift
@@ -237,7 +237,7 @@ public struct ResourcePack {
     let mcMeta: ResourcePack.PackMCMeta
     do {
       let data = try Data(contentsOf: mcMetaFile)
-      mcMeta = try ZippyJSONDecoder().decode(ResourcePack.PackMCMeta.self, from: data)
+      mcMeta = try CustomJSONDecoder().decode(ResourcePack.PackMCMeta.self, from: data)
     } catch {
       throw ResourcePackError.failedToReadMCMeta(error)
     }
@@ -348,7 +348,7 @@ public struct ResourcePack {
     let versionsManifest: VersionsManifest
     do {
       let data = try Data(contentsOf: versionsManifestURL)
-      versionsManifest = try ZippyJSONDecoder().decode(VersionsManifest.self, from: data)
+      versionsManifest = try CustomJSONDecoder().decode(VersionsManifest.self, from: data)
     } catch {
       throw ResourcePackError.versionsManifestFailure(error)
     }
@@ -368,7 +368,7 @@ public struct ResourcePack {
     let versionManifest: VersionManifest
     do {
       let data = try Data(contentsOf: versionURL)
-      versionManifest = try ZippyJSONDecoder().decode(VersionManifest.self, from: data)
+      versionManifest = try CustomJSONDecoder().decode(VersionManifest.self, from: data)
     } catch {
       throw ResourcePackError.versionManifestFailure(error)
     }

--- a/Sources/Core/Sources/Resources/Texture/Texture.swift
+++ b/Sources/Core/Sources/Resources/Texture/Texture.swift
@@ -128,7 +128,7 @@ public struct Texture {
     let numFrames = height / width
     do {
       let data = try Data(contentsOf: animationMetadataFile)
-      let animationMCMeta = try ZippyJSONDecoder().decode(AnimationMCMeta.self, from: data)
+      let animationMCMeta = try CustomJSONDecoder().decode(AnimationMCMeta.self, from: data)
       animation = Animation(from: animationMCMeta, maxFrameIndex: numFrames)
     } catch {
       throw TextureError.failedToLoadTextureAnimation(error)

--- a/Sources/Core/Sources/Util/CustomJSONDecoder.swift
+++ b/Sources/Core/Sources/Util/CustomJSONDecoder.swift
@@ -5,10 +5,14 @@ import ZippyJSON
 
 public struct CustomJSONDecoder {
   #if !os(Linux)
-  public var keyDecodingStrategy: ZippyJSONDecoder.KeyDecodingStrategy
+  public var keyDecodingStrategy: ZippyJSONDecoder.KeyDecodingStrategy = ZippyJSONDecoder.KeyDecodingStrategy.convertFromSnakeCase
   #else
-  public var keyDecodingStrategy: JSONDecoder.KeyDecodingStrategy
+  public var keyDecodingStrategy: JSONDecoder.KeyDecodingStrategy = JSONDecoder.KeyDecodingStrategy.convertFromSnakeCase
   #endif
+
+  public init() {
+    // Empty initialiser because we do not want the keyDecodingStrategy to be an initialiser parameter
+  }
 
   public func decode<T: Decodable>(_ type: T.Type, from data: Data) throws -> T {
     #if !os(Linux)

--- a/Sources/Core/Sources/Util/CustomJSONDecoder.swift
+++ b/Sources/Core/Sources/Util/CustomJSONDecoder.swift
@@ -10,6 +10,6 @@ public struct CustomJSONDecoder {
     #else
     let decoder = JSONDecoder()
     #endif
-    return decoder.decode(type, from: data)
+    return try decoder.decode(type, from: data)
   }
 }

--- a/Sources/Core/Sources/Util/CustomJSONDecoder.swift
+++ b/Sources/Core/Sources/Util/CustomJSONDecoder.swift
@@ -5,9 +5,9 @@ import ZippyJSON
 
 public struct CustomJSONDecoder {
   #if !os(Linux)
-  public var keyDecodingStrategy: ZippyJSONDecoder.KeyDecodingStrategy = ZippyJSONDecoder.KeyDecodingStrategy.convertFromSnakeCase
+  public var keyDecodingStrategy: ZippyJSONDecoder.KeyDecodingStrategy = ZippyJSONDecoder.KeyDecodingStrategy.useDefaultKeys
   #else
-  public var keyDecodingStrategy: JSONDecoder.KeyDecodingStrategy = JSONDecoder.KeyDecodingStrategy.convertFromSnakeCase
+  public var keyDecodingStrategy: JSONDecoder.KeyDecodingStrategy = JSONDecoder.KeyDecodingStrategy.useDefaultKeys
   #endif
 
   public init() {

--- a/Sources/Core/Sources/Util/CustomJSONDecoder.swift
+++ b/Sources/Core/Sources/Util/CustomJSONDecoder.swift
@@ -1,0 +1,15 @@
+import Foundation
+#if !os(Linux)
+import ZippyJSON
+#endif
+
+public struct CustomJSONDecoder {
+  public func decode<T: Decodable>(_ type: T.Type, from data: Data) throws -> T {
+    #if !os(Linux)
+    let decoder = CustomJSONDecoder()
+    #else
+    let decoder = JSONDecoder()
+    #endif
+    return decoder.decode(type, from: data)
+  }
+}

--- a/Sources/Core/Sources/Util/CustomJSONDecoder.swift
+++ b/Sources/Core/Sources/Util/CustomJSONDecoder.swift
@@ -4,12 +4,19 @@ import ZippyJSON
 #endif
 
 public struct CustomJSONDecoder {
+  #if !os(Linux)
+  public var keyDecodingStrategy: ZippyJSONDecoder.KeyDecodingStrategy
+  #else
+  public var keyDecodingStrategy: JSONDecoder.KeyDecodingStrategy
+  #endif
+
   public func decode<T: Decodable>(_ type: T.Type, from data: Data) throws -> T {
     #if !os(Linux)
-    let decoder = CustomJSONDecoder()
+    let decoder = ZippyJSONDecoder()
     #else
     let decoder = JSONDecoder()
     #endif
+    decoder.keyDecodingStrategy = self.keyDecodingStrategy
     return try decoder.decode(type, from: data)
   }
 }

--- a/Sources/Core/Sources/Util/TickScheduler.swift
+++ b/Sources/Core/Sources/Util/TickScheduler.swift
@@ -1,4 +1,4 @@
-import Concurrency
+import Atomics
 import Foundation
 import Darwin
 import FirebladeECS
@@ -27,7 +27,7 @@ public final class TickScheduler {
   /// The systems to run each tick. In execution order.
   public var systems: [System] = []
   /// If `true`, the tick loop will be stopped at the start of the next tick.
-  private var shouldCancel: AtomicBool = AtomicBool(initialValue: false)
+  private var shouldCancel = ManagedAtomic<Bool>(false)
   /// Time base information used in time calculations.
   private var timebaseInfo = mach_timebase_info_data_t()
   

--- a/Sources/Core/Sources/Util/TickScheduler.swift
+++ b/Sources/Core/Sources/Util/TickScheduler.swift
@@ -65,7 +65,7 @@ public final class TickScheduler {
   
   /// Cancels the scheduler at the start of the next tick.
   public func cancel() {
-    shouldCancel.value = true
+    shouldCancel.store(true, ordering: .relaxed)
   }
   
   /// Should only be called once on a given tick scheduler.
@@ -77,7 +77,7 @@ public final class TickScheduler {
         self.mostRecentTick = CFAbsoluteTimeGetCurrent()
         let nanosecondsPerTick = UInt64(1 / self.ticksPerSecond * Double(NSEC_PER_SEC))
         var when = mach_absolute_time()
-        while !self.shouldCancel.value {
+        while !self.shouldCancel.load(ordering: .relaxed) {
           when += self.nanosToAbs(nanosecondsPerTick)
           mach_wait_until(when)
           self.mostRecentTick = CFAbsoluteTimeGetCurrent()


### PR DESCRIPTION
# Description

This PR creates a CustomJSONDecoder struct, which wraps around the ZippyJSONDecoder and JSONDecoder `decode` method depending on platform. ZippyJSONDecoder is used on all platforms except Linux, where it is not currently supported.

Additionally, this PR replaces swift-concurrency with swift-atomics, which builds on Linux. Thanks to [LeoDog896](https://github.com/LeoDog896/delta-client/commit/63cbe2035330b2c2c2028e7b3d9878322cfa39c2) for originally making this change.

This should warrant an update to #113.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where required, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation comments
- [x] My changes generate no new warnings
