### PR TITLE
Availability based MetalView struct/class for macOS 13 Ventura

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -204,7 +204,7 @@
         "repositoryURL": "https://github.com/weichsel/ZIPFoundation.git",
         "state": {
           "branch": null,
-          "revision": "7254c74b49cec2cb81520523ba993c671f71b066",
+          "revision": "1b662e2e7a091710ad8a963263939984e2ebf527",
           "version": "0.9.14"
         }
       },

--- a/Sources/Client/Views/Play/GameView.swift
+++ b/Sources/Client/Views/Play/GameView.swift
@@ -274,17 +274,33 @@ struct GameView: View {
   var gameView: some View {
     ZStack {
       // Renderer
-      MetalView(renderCoordinator: model.renderCoordinator)
-        .onAppear {
-          model.inputDelegate.bind($cursorCaptured.onChange { newValue in
-            // When showing overlay make sure menu is the first view
-            if newValue == false {
-              model.overlayState.update(to: .menu)
-            }
-          })
+        if #available(macOS 13, iOS 16, *) {
+            MetalView(renderCoordinator: model.renderCoordinator)
+              .onAppear {
+                model.inputDelegate.bind($cursorCaptured.onChange { newValue in
+                  // When showing overlay make sure menu is the first view
+                  if newValue == false {
+                    model.overlayState.update(to: .menu)
+                  }
+                })
 
-          model.inputDelegate.captureCursor()
+                model.inputDelegate.captureCursor()
+              }
         }
+        else {
+            MetalViewClass(renderCoordinator: model.renderCoordinator)
+              .onAppear {
+                model.inputDelegate.bind($cursorCaptured.onChange { newValue in
+                  // When showing overlay make sure menu is the first view
+                  if newValue == false {
+                    model.overlayState.update(to: .menu)
+                  }
+                })
+
+                model.inputDelegate.captureCursor()
+              }
+        }
+      
 
       #if os(iOS)
       movementControls

--- a/Sources/Client/Views/Play/MetalView.swift
+++ b/Sources/Client/Views/Play/MetalView.swift
@@ -3,7 +3,9 @@ import DeltaCore
 import MetalKit
 import SwiftUI
 
-final class MetalView {
+@available(macOS 13, *)
+@available(iOS 16, *)
+struct MetalView {
   var renderCoordinator: RenderCoordinator
   
   init(renderCoordinator: RenderCoordinator) {
@@ -35,8 +37,54 @@ final class MetalView {
   }
 }
 
+@available(macOS, deprecated: 13, renamed: "MetalView")
+@available(iOS, deprecated: 16, renamed: "MetalView")
+final class MetalViewClass {
+  var renderCoordinator: RenderCoordinator
+  
+  init(renderCoordinator: RenderCoordinator) {
+    self.renderCoordinator = renderCoordinator
+  }
+
+  func makeCoordinator() -> RenderCoordinator {
+    return renderCoordinator
+  }
+
+  func makeMTKView(renderCoordinator: RenderCoordinator) -> MTKView {
+    let mtkView = MTKView()
+    
+    if let metalDevice = MTLCreateSystemDefaultDevice() {
+      mtkView.device = metalDevice
+    }
+    
+    mtkView.delegate = renderCoordinator
+    mtkView.preferredFramesPerSecond = 10000
+    mtkView.framebufferOnly = true
+    mtkView.clearColor = MTLClearColorMake(0.65, 0.8, 1, 1) // Sky colour
+    mtkView.drawableSize = mtkView.frame.size
+    mtkView.depthStencilPixelFormat = .depth32Float
+    mtkView.clearDepth = 1.0
+    
+    // Accept input
+    mtkView.becomeFirstResponder()
+    return mtkView
+  }
+}
+
+
 #if os(macOS)
+
+@available(macOS 13, *)
+@available(iOS 16, *)
 extension MetalView: NSViewRepresentable {
+  func makeNSView(context: Context) -> some NSView {
+    return makeMTKView(renderCoordinator: context.coordinator)
+  }
+  
+  func updateNSView(_ view: NSViewType, context: Context) {}
+}
+
+extension MetalViewClass: NSViewRepresentable {
   func makeNSView(context: Context) -> some NSView {
     return makeMTKView(renderCoordinator: context.coordinator)
   }


### PR DESCRIPTION
# Description
This PR fixes crash on newest macOS Ventura which expects NSViewRepresentable to be a value type. Issue occurs when user joins a game. Crash was immediate, no feedback.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation comments
- [x] My changes generate no new warnings
