### PR TITLE
[Bug Fix] Render entities before translucent geometry for correct blending.

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -11,15 +11,6 @@
         }
       },
       {
-        "package": "CryptoSwift",
-        "repositoryURL": "https://github.com/krzyzanowskim/CryptoSwift.git",
-        "state": {
-          "branch": null,
-          "revision": "5669f222e46c8134fb1f399c745fa6882b43532e",
-          "version": "1.3.8"
-        }
-      },
-      {
         "package": "DeltaLogger",
         "repositoryURL": "https://github.com/stackotter/delta-logger",
         "state": {

--- a/Sources/Core/Sources/Render/RenderCoordinator.swift
+++ b/Sources/Core/Sources/Render/RenderCoordinator.swift
@@ -16,9 +16,6 @@ public final class RenderCoordinator: NSObject, MTKViewDelegate {
   /// The renderer for the current world. Only renders blocks.
   private var worldRenderer: WorldRenderer
 
-  /// The renderer for rendering entities.
-  private var entityRenderer: EntityRenderer
-
   /// The renderer for rendering the GUI.
   private var guiRenderer: GUIRenderer
 
@@ -84,17 +81,6 @@ public final class RenderCoordinator: NSObject, MTKViewDelegate {
       )
     } catch {
       fatalError("Failed to create world renderer: \(error)")
-    }
-
-    do {
-      entityRenderer = try EntityRenderer(
-        client: client,
-        device: device,
-        commandQueue: commandQueue,
-        profiler: profiler
-      )
-    } catch {
-      fatalError("Failed to create entity renderer: \(error)")
     }
 
     do {
@@ -194,22 +180,6 @@ public final class RenderCoordinator: NSObject, MTKViewDelegate {
     } catch {
       log.error("Failed to render world: \(error)")
       client.eventBus.dispatch(ErrorEvent(error: error, message: "Failed to render world"))
-      return
-    }
-    profiler.pop()
-
-    profiler.push(.entities)
-    do {
-      try entityRenderer.render(
-        view: view,
-        encoder: renderEncoder,
-        commandBuffer: commandBuffer,
-        worldToClipUniformsBuffer: uniformsBuffer,
-        camera: camera
-      )
-    } catch {
-      log.error("Failed to render entities: \(error)")
-      client.eventBus.dispatch(ErrorEvent(error: error, message: "Failed to render entities"))
       return
     }
     profiler.pop()


### PR DESCRIPTION


# Description
This PR moves `entityRenderer` inside of `worldRenderer` for flexible control over rendering order.
Rendering entities is encoded after drawing focused block outline, but before translucent geometry rendering for correct alpha blending behaviour.

Fixes #123

Profiled and tested on latest release and beta versions of macOS (Monterey / Ventura respectively).

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation comments
- [x] My changes generate no new warnings
