### PR TITLE
Gamemode dependent block outline rendering.

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -105,8 +105,8 @@
         "repositoryURL": "https://github.com/apple/swift-log",
         "state": {
           "branch": null,
-          "revision": "5d66f7ba25daf4f94100e7022febf3c75e37a6c7",
-          "version": "1.4.2"
+          "revision": "6fe203dc33195667ce1759bf0182975e4653ba1c",
+          "version": "1.4.4"
         }
       },
       {
@@ -141,8 +141,8 @@
         "repositoryURL": "https://github.com/apple/swift-protobuf.git",
         "state": {
           "branch": null,
-          "revision": "e1499bc69b9040b29184f7f2996f7bab467c1639",
-          "version": "1.19.0"
+          "revision": "88c7d15e1242fdb6ecbafbc7926426a19be1e98a",
+          "version": "1.20.2"
         }
       },
       {
@@ -195,8 +195,8 @@
         "repositoryURL": "https://github.com/weichsel/ZIPFoundation.git",
         "state": {
           "branch": null,
-          "revision": "1b662e2e7a091710ad8a963263939984e2ebf527",
-          "version": "0.9.14"
+          "revision": "f6a22e7da26314b38bf9befce34ae8e4b2543090",
+          "version": "0.9.15"
         }
       },
       {
@@ -204,8 +204,8 @@
         "repositoryURL": "https://github.com/michaeleisel/ZippyJSON",
         "state": {
           "branch": null,
-          "revision": "1ab389998592d038a60a3ca71aa7554d0e84ab4a",
-          "version": "1.2.4"
+          "revision": "31b991dfec66a4489b49142e7e5c0060e434f0ec",
+          "version": "1.2.5"
         }
       },
       {

--- a/Sources/Core/Sources/Game.swift
+++ b/Sources/Core/Sources/Game.swift
@@ -267,8 +267,16 @@ public struct Game {
   /// Gets the position of the block currently targeted by the player.
   public func targetedBlock() -> BlockPosition? {
     var ray: Ray = Ray(origin: .zero, direction: .zero)
+    var targetable: Bool = true
+    
     accessPlayer { player in
       ray = player.ray
+      targetable = player.gamemode.gamemode != .spectator
+    }
+    
+    /// Make sure current gamemode allows targeting blocks. If not (Spectator), perform early exit.
+    guard targetable else {
+      return nil
     }
 
     for position in VoxelRay(along: ray, count: 7) {

--- a/Sources/Core/Sources/Game.swift
+++ b/Sources/Core/Sources/Game.swift
@@ -267,16 +267,9 @@ public struct Game {
   /// Gets the position of the block currently targeted by the player.
   public func targetedBlock() -> BlockPosition? {
     var ray: Ray = Ray(origin: .zero, direction: .zero)
-    var targetable: Bool = true
     
     accessPlayer { player in
       ray = player.ray
-      targetable = player.gamemode.gamemode != .spectator
-    }
-    
-    /// Make sure current gamemode allows targeting blocks. If not (Spectator), perform early exit.
-    guard targetable else {
-      return nil
     }
 
     for position in VoxelRay(along: ray, count: 7) {
@@ -293,6 +286,16 @@ public struct Game {
     }
 
     return nil
+  }
+  
+  /// Gets current gamemode of the player
+  public func currentGamemode() -> Gamemode? {
+    var gamemode: Gamemode? = nil
+    accessPlayer { player in
+      gamemode = player.gamemode.gamemode
+    }
+    
+    return gamemode
   }
 
   // MARK: Lifecycle

--- a/Sources/Core/Sources/Render/World/WorldRenderer.swift
+++ b/Sources/Core/Sources/Render/World/WorldRenderer.swift
@@ -38,9 +38,10 @@ public final class WorldRenderer: Renderer {
   /// A buffer containing indices for a block outline.
   private let blockOutlineIndexBuffer: MTLBuffer
   
+  /// Determines whether block outline rendering should be performed
   private var renderBlockOutline: Bool {
     let playerGamemode = client.game.currentGamemode()
-    guard let playerGamemode else {
+    guard let playerGamemode = playerGamemode else {
       return false
     }
     

--- a/Sources/Core/Sources/Render/World/WorldRenderer.swift
+++ b/Sources/Core/Sources/Render/World/WorldRenderer.swift
@@ -37,16 +37,6 @@ public final class WorldRenderer: Renderer {
   private let blockOutlineVertexBuffer: MTLBuffer
   /// A buffer containing indices for a block outline.
   private let blockOutlineIndexBuffer: MTLBuffer
-  
-  /// Determines whether block outline rendering should be performed
-  private var renderBlockOutline: Bool {
-    let playerGamemode = client.game.currentGamemode()
-    guard let playerGamemode = playerGamemode else {
-      return false
-    }
-    
-    return playerGamemode != .spectator
-  }
 
   // MARK: Init
 
@@ -176,7 +166,7 @@ public final class WorldRenderer: Renderer {
     }
     profiler.pop()
 
-    if renderBlockOutline {
+    if client.game.currentGamemode() != .spectator {
       // Render selected block outline
       profiler.push(.encodeBlockOutline)
       if let targetedBlockPosition = client.game.targetedBlock() {


### PR DESCRIPTION
# Description

This PR fixes the case where blocks are given target outlines when player's current gamemode is Spectator mode.

Block targetability is determined in function returning targeted block position. Returning `nil` value in aforementioned function naturally prevents rendering of block outline in `worldRenderer` main `render` loop (no block position data available).

Initial approach was to use computed variable in `worldRender`, however, proposed solution seemed much more elegant (single thread-safe player data fetch).

Fixes #137 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation comments
- [x] My changes generate no new warnings
