### PR TITLE
Errors ergonomics improvement

### DIFF
--- a/Sources/Core/Sources/Account/Microsoft/MicrosoftAPI.swift
+++ b/Sources/Core/Sources/Account/Microsoft/MicrosoftAPI.swift
@@ -345,7 +345,7 @@ public enum MicrosoftAPI {
       do {
         error = try decodeResponse(data)
       } catch {
-        throw MicrosoftAPIError.failedToDeserializeResponse(error, String(data: data, encoding: .utf8) ?? "")
+        throw MicrosoftAPIError.failedToDeserializeResponse(error, String(decoding: data, as: UTF8.self))
       }
       
       throw MicrosoftAPIError.xstsAuthenticationFailed(error)
@@ -400,7 +400,7 @@ public enum MicrosoftAPI {
     do {
       return try CustomJSONDecoder().decode(Response.self, from: data)
     } catch {
-      throw MicrosoftAPIError.failedToDeserializeResponse(error, String(data: data, encoding: .utf8) ?? "")
+      throw MicrosoftAPIError.failedToDeserializeResponse(error, String(decoding: data, as: UTF8.self))
     }
   }
 }

--- a/Sources/Core/Sources/Account/Microsoft/Response/XSTSAuthenticationError.swift
+++ b/Sources/Core/Sources/Account/Microsoft/Response/XSTSAuthenticationError.swift
@@ -1,10 +1,10 @@
 import Foundation
 
 public struct XSTSAuthenticationError: Codable {
-  public var identity: String
-  public var code: Int
-  public var message: String
-  public var redirect: String
+  public let identity: String
+  public let code: Int
+  public let message: String
+  public let redirect: String
   
   enum CodingKeys: String, CodingKey {
     case identity = "Identity"

--- a/Sources/Core/Sources/Account/Mojang/MojangAPI.swift
+++ b/Sources/Core/Sources/Account/Mojang/MojangAPI.swift
@@ -42,7 +42,7 @@ public enum MojangAPI {
     let (_, data) = try await RequestUtil.performJSONRequest(url: authenticationURL, body: payload, method: .post)
     
     guard let response = try? CustomJSONDecoder().decode(MojangAuthenticationResponse.self, from: data) else {
-      throw MojangAPIError.failedToDeserializeResponse(String(data: data, encoding: .utf8) ?? "")
+      throw MojangAPIError.failedToDeserializeResponse(String(decoding: data, as: UTF8.self))
     }
     
     let accessToken = MinecraftAccessToken(
@@ -92,7 +92,7 @@ public enum MojangAPI {
     let (_, data) = try await RequestUtil.performJSONRequest(url: refreshURL, body: payload, method: .post)
     
     guard let response = try? CustomJSONDecoder().decode(MojangRefreshTokenResponse.self, from: data) else {
-      throw MojangAPIError.failedToDeserializeResponse(String(data: data, encoding: .utf8) ?? "")
+      throw MojangAPIError.failedToDeserializeResponse(String(decoding: data, as: UTF8.self))
     }
     
     var refreshedAccount = account

--- a/Sources/Core/Sources/Network/Protocol/Packets/Play/Clientbound/EntityAttributesPacket.swift
+++ b/Sources/Core/Sources/Network/Protocol/Packets/Play/Clientbound/EntityAttributesPacket.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 public enum EntityAttributesPacketError: LocalizedError {
-  case invalidModifierOperationRawValue(UInt8)
+  case invalidModifierOperationRawValue(EntityAttributeModifier.Operation.RawValue)
   case invalidAttributeKey(String)
   
   public var errorDescription: String? {

--- a/Sources/Core/Sources/Network/Protocol/Packets/Play/Clientbound/RespawnPacket.swift
+++ b/Sources/Core/Sources/Network/Protocol/Packets/Play/Clientbound/RespawnPacket.swift
@@ -1,8 +1,8 @@
 import Foundation
 
 public enum RespawnPacketError: LocalizedError {
-  case invalidGamemodeRawValue(Int8)
-  case invalidPreviousGamemodeRawValue(Int8)
+  case invalidGamemodeRawValue(Gamemode.RawValue)
+  case invalidPreviousGamemodeRawValue(Gamemode.RawValue)
   
   public var errorDescription: String? {
     switch self {

--- a/Sources/Core/Sources/Plugin/PluginEnvironment.swift
+++ b/Sources/Core/Sources/Plugin/PluginEnvironment.swift
@@ -40,9 +40,10 @@ public class PluginEnvironment: ObservableObject {
   /// An error related to a particular plugin.
   public struct PluginError: LocalizedError {
     /// The bundle of the plugin that the error occurred for.
-    public var bundle: String 
+    public let bundle: String
     /// The underlying error that caused this error to be thrown if any.
-    public var underlyingError: Error
+    public let underlyingError: Error
+    
     public var errorDescription: String? {
       """
       \(String(describing: Self.self)).

--- a/Sources/Core/Sources/Resources/Model/Block/BlockModelPaletteError.swift
+++ b/Sources/Core/Sources/Resources/Model/Block/BlockModelPaletteError.swift
@@ -22,7 +22,7 @@ enum BlockModelPaletteError: LocalizedError {
   /// A matrix was stored with an invalid number of bytes in the Protobuf cache. Expected to be 64.
   case invalidMatrixDataLength(Int)
   /// Invalid computed tint type in cached protobuf message.
-  case invalidComputedTintTypeRawValue(Int)
+  case invalidComputedTintTypeRawValue(ProtobufBlockComputedTintType.RawValue)
   /// Invalid block tint in cached protobuf message.
   case invalidBlockTint
   /// Invalid block offset in cached protobuf message.


### PR DESCRIPTION
# Description

- change `let` to `var` in errors
  - I saw that overall project uses `var` instead of `let` but in my opinion at least errors should be fully immutable because I do not see any scenario where you should mutate and error (so as there were no error mutations in the project).
- Change `String(data:encoding:)` to `String(decoding:as:)`. It's better to provide info with � symbols if not UTF8 rather than an empty string.
- use RawValue in errors instead of actual RawValue type (e.g. instead on `Int` use `Struct.RawValue`). Easier to refactor code 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation comments
- [x] My changes generate no new warnings
