### PR TITLE
Cancel update if the current version is already the latest commit

### DIFF
--- a/Sources/Client/Util/Updater.swift
+++ b/Sources/Client/Util/Updater.swift
@@ -57,7 +57,7 @@ public final class Updater: ObservableObject {
       do {
         (downloadURL, downloadVersion) = try self.getDownloadURL(self.updateType)
       } catch {
-        DeltaClientApp.modalError("Failed to get download URL", safeState: .serverList)
+        DeltaClientApp.modalError("Failed to get download URL: \(error.localizedDescription)", safeState: .serverList)
         return
       }
 
@@ -215,6 +215,14 @@ public final class Updater: ObservableObject {
   private static func getLatestUnstableDownloadURL(branch: String) throws -> (URL, String) {
     let branches = try getBranches()
     let commit = branches.filter { $0.name == branch }.first?.commit.sha.prefix(7) ?? "<unknown>"
+
+    if let currentVersionString = Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String {
+      let currentCommit = currentVersionString[currentVersionString.range(of: "commit: ")!.upperBound...]
+      if currentCommit == commit {
+        throw UpdateError.alreadyUpToDate(currentCommit)
+      }
+    }
+
     let url = URL(string: "https://backend.deltaclient.app/download/\(branch)/latest/DeltaClient.app.zip")!
     return (url, "commit \(commit) (latest)")
   }

--- a/Sources/Client/Views/Settings/UpdateView.swift
+++ b/Sources/Client/Views/Settings/UpdateView.swift
@@ -11,6 +11,7 @@ enum UpdateViewState {
 enum UpdateError: LocalizedError {
   case failedToGetDownloadURL
   case failedToGetDownloadURLFromGitHubReleases
+  case alreadyUpToDate(String.SubSequence)
   case failedToGetBranches(Error)
   case failedToGetGitHubAPIResponse(Error)
   
@@ -20,6 +21,8 @@ enum UpdateError: LocalizedError {
         return "Failed to get download URL."
       case .failedToGetDownloadURLFromGitHubReleases:
         return "Failed to get download URL from GitHub Releases."
+      case .alreadyUpToDate(let commit):
+        return "You are already up to date (commit \(commit))"
       case .failedToGetBranches(let error):
         return """
         Failed to get branches.


### PR DESCRIPTION
# Description

This PR prevents the user from updating via the in-app updater if it would only update them to the same commit they already have.

Fixes #16 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
