### PR TITLE
Struct variant for WebView on macOS 13 Ventura

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -47,6 +47,15 @@
         }
       },
       {
+        "package": "SourceKitten",
+        "repositoryURL": "https://github.com/jpsim/SourceKitten.git",
+        "state": {
+          "branch": null,
+          "revision": "817dfa6f2e09b0476f3a6c9dbc035991f02f0241",
+          "version": "0.32.0"
+        }
+      },
+      {
         "package": "swift-argument-parser",
         "repositoryURL": "https://github.com/apple/swift-argument-parser",
         "state": {
@@ -71,6 +80,15 @@
           "branch": null,
           "revision": "9d8719c8bebdc79740b6969c912ac706eb721d7a",
           "version": "0.0.7"
+        }
+      },
+      {
+        "package": "SwiftLintPlugin",
+        "repositoryURL": "https://github.com/stackotter/swift-lint-plugin",
+        "state": {
+          "branch": null,
+          "revision": "f887b764032df4862fc56d831ca1ed0e2e8cdf86",
+          "version": "0.1.1"
         }
       },
       {
@@ -128,12 +146,48 @@
         }
       },
       {
+        "package": "SwiftLint",
+        "repositoryURL": "https://github.com/stackotter/SwiftLint",
+        "state": {
+          "branch": null,
+          "revision": "b4a54f32df66008d30f0229446831cb823576c42",
+          "version": "0.46.2"
+        }
+      },
+      {
+        "package": "SwiftyTextTable",
+        "repositoryURL": "https://github.com/scottrhoyt/SwiftyTextTable.git",
+        "state": {
+          "branch": null,
+          "revision": "c6df6cf533d120716bff38f8ff9885e1ce2a4ac3",
+          "version": "0.9.0"
+        }
+      },
+      {
         "package": "SwordRPC",
         "repositoryURL": "https://github.com/stackotter/SwordRPC",
         "state": {
           "branch": null,
           "revision": "3ddf125eeb3d83cb17a6e4cda685f9c80e0d4bed",
           "version": null
+        }
+      },
+      {
+        "package": "SWXMLHash",
+        "repositoryURL": "https://github.com/drmohundro/SWXMLHash.git",
+        "state": {
+          "branch": null,
+          "revision": "6469881a3f30417c5bb02404ea4b69207f297592",
+          "version": "6.0.0"
+        }
+      },
+      {
+        "package": "Yams",
+        "repositoryURL": "https://github.com/jpsim/Yams.git",
+        "state": {
+          "branch": null,
+          "revision": "9ff1cc9327586db4e0c8f46f064b6a82ec1566fa",
+          "version": "4.0.6"
         }
       },
       {

--- a/Sources/Client/Views/Settings/Account/MicrosoftLoginView.swift
+++ b/Sources/Client/Views/Settings/Account/MicrosoftLoginView.swift
@@ -20,8 +20,11 @@ struct MicrosoftLoginView: View {
           Text(errorMessage)
             .foregroundColor(.red)
         }
-        
-        WebView(request: URLRequest(url: MicrosoftAPI.getAuthorizationURL()), urlChangeHandler: processURLChange)
+        if #available(macOS 13, iOS 16, *) {
+          WebView(request: URLRequest(url: MicrosoftAPI.getAuthorizationURL()), urlChangeHandler: processURLChange)
+        } else {
+          WebViewClass(request: URLRequest(url: MicrosoftAPI.getAuthorizationURL()), urlChangeHandler: processURLChange)
+        }
       case .authenticating:
         Text("Authenticating...")
     }

--- a/Sources/Client/Views/Settings/Account/WebView.swift
+++ b/Sources/Client/Views/Settings/Account/WebView.swift
@@ -1,7 +1,51 @@
 import SwiftUI
 import WebKit
 
-final class WebView {
+@available(macOS 13, *)
+@available(iOS 16, *)
+struct WebView {
+  @State var request: URLRequest
+  var urlChangeHandler: (URL) -> Void
+  
+  @State var observer: NSKeyValueObservation?
+  
+  // TODO: investigate weak variables
+  // swiftlint:disable weak_delegate
+  var delegate = WebViewDelegate()
+  // swiftlint:enable weak_delegate
+  
+  func makeView(context: Context) -> WKWebView {
+    let config = WKWebViewConfiguration()
+    config.limitsNavigationsToAppBoundDomains = true
+    
+    let webview = WKWebView()
+    webview.navigationDelegate = delegate
+    
+    // Register observation for url changes
+    // Async so we are not editing stateful during view update
+    DispatchQueue(label: "dev.stackotter.delta-client.webview").async {
+      observer = webview.observe(\.url, options: .new) { view, _ in
+        if let newURL = view.url {
+          self.urlChangeHandler(newURL)
+        }
+      }
+    }
+    return webview
+  }
+
+  func updateView(_ view: WKWebView, context: Context) {
+    if view.url == nil {
+      DispatchQueue(label: "dev.stackotter.delta-client.webview").async {
+        request.httpShouldHandleCookies = false
+      }
+      view.load(request)
+    }
+  }
+}
+
+@available(macOS, deprecated: 13, renamed: "WebView")
+@available(iOS, deprecated: 16, renamed: "WebView")
+final class WebViewClass {
   var request: URLRequest
   var urlChangeHandler: (URL) -> Void
   
@@ -42,7 +86,20 @@ final class WebView {
 }
 
 #if os(macOS)
+@available(macOS 13, *)
 extension WebView: NSViewRepresentable {
+  typealias NSViewType = WKWebView
+  
+  func makeNSView(context: Context) -> WKWebView {
+    return makeView(context: context)
+  }
+  
+  func updateNSView(_ view: WKWebView, context: Context) {
+    updateView(view, context: context)
+  }
+}
+
+extension WebViewClass: NSViewRepresentable {
   final func makeNSView(context: Context) -> WKWebView {
     return makeView(context: context)
   }
@@ -52,7 +109,20 @@ extension WebView: NSViewRepresentable {
   }
 }
 #elseif os(iOS)
+@available(iOS 16, *)
 extension WebView: UIViewRepresentable {
+  typealias UIViewType = WKWebView
+  
+  func makeUIView(context: Context) -> WKWebView {
+    return makeView(context: context)
+  }
+  
+  func updateUIView(_ view: WKWebView, context: Context) {
+    updateView(view, context: context)
+  }
+}
+
+extension WebViewClass: UIViewRepresentable {
   final func makeUIView(context: Context) -> WKWebView {
     return makeView(context: context)
   }


### PR DESCRIPTION
# Description

This PR fixes the NSViewRepresentable value type issue for WebView on macOS Ventura. Similar to #135, just applying the same idea to WebView.

A few notable things:
- WebView variables had to be marked with `@State` to avoid struct immutability
  - To not change state values during view updates, most mutating operations use `DispatchQueue().asnyc { }`
  - Not entirely sure how this affects how the code runs, seems to be the same
- Is it necessary to use `if #available(macOS 13, iOS 16, *)`? Is there any reason to keep the class version?
- iOS 16 might have the same issue. Preliminary code is in place, but I don't have swift-bundler for iOS
  - Does #135 fix it on iOS?

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation comments
- [ ] My changes generate no new warnings
  - [x] Tested on macOS
  - [ ] Tested on iOS
