### PR TITLE
Upwards facing liquid mesh culling

### DIFF
--- a/Sources/Core/Renderer/Mesh/FluidMeshBuilder.swift
+++ b/Sources/Core/Renderer/Mesh/FluidMeshBuilder.swift
@@ -107,9 +107,11 @@ struct FluidMeshBuilder { // TODO: Make fluid meshes look more like they do in v
     tint: Vec3f
   ) {
     let basePosition = position.relativeToChunkSection.floatVector + Vec3f(0.5, 0, 0.5)
+    var cullingFluid = cullingNeighbours
+    if neighbouringBlocks[.up]?.fluidId != fluid.id { cullingFluid.remove(.up) }
 
     // Iterate through all visible faces
-    for direction in Direction.allDirections where !cullingNeighbours.contains(direction) {
+    for direction in Direction.allDirections where !cullingFluid.contains(direction) {
       let shade = CubeGeometry.shades[direction.rawValue]
       let tint = tint * shade
 

--- a/Sources/Core/Renderer/Mesh/FluidMeshBuilder.swift
+++ b/Sources/Core/Renderer/Mesh/FluidMeshBuilder.swift
@@ -107,11 +107,14 @@ struct FluidMeshBuilder { // TODO: Make fluid meshes look more like they do in v
     tint: Vec3f
   ) {
     let basePosition = position.relativeToChunkSection.floatVector + Vec3f(0.5, 0, 0.5)
-    var cullingFluid = cullingNeighbours
-    if neighbouringBlocks[.up]?.fluidId != fluid.id { cullingFluid.remove(.up) }
+    // Make cullingNeighbours multable and prevent top face culling when covered by non-liquids
+    var cullingNeighbours = cullingNeighbours
+    if neighbouringBlocks[.up]?.fluidId != fluid.id {
+      cullingNeighbours.remove(.up)
+    }
 
     // Iterate through all visible faces
-    for direction in Direction.allDirections where !cullingFluid.contains(direction) {
+    for direction in Direction.allDirections where !cullingNeighbours.contains(direction) {
       let shade = CubeGeometry.shades[direction.rawValue]
       let tint = tint * shade
 


### PR DESCRIPTION
# Description

Addresses an issue where liquids would not render the top face of their mesh when a block is directly above.
Fixes #47 

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation comments
- [x] My changes generate no new warnings
