### PR TITLE
Resolve issue #67 and fix Metal crash on Intel iGPU devices

### DIFF
--- a/Sources/Client/Views/Play/GameView.swift
+++ b/Sources/Client/Views/Play/GameView.swift
@@ -200,7 +200,7 @@ struct GameView: View {
   }
 
   var body: some View {
-    Group {
+    VStack {
       switch model.state.current {
         case .connecting:
           connectingView

--- a/Sources/Core/Renderer/ScreenRenderer.swift
+++ b/Sources/Core/Renderer/ScreenRenderer.swift
@@ -75,6 +75,9 @@ public final class ScreenRenderer: Renderer {
 
     // Update pixel format for depth texture. Match other texture parameters with colour attachment (above).
     nativeRenderTextureDescriptor.pixelFormat = .depth32Float
+    if device.hasUnifiedMemory {
+      nativeRenderTextureDescriptor.storageMode = .private
+    }
     guard let depthTexture = device.makeTexture(descriptor: nativeRenderTextureDescriptor) else {
       throw RenderError.failedToUpdateRenderTargetSize
     }


### PR DESCRIPTION
# Description

This PR resolves issue #67. It was caused by disconnecting the socket in a mistakenly called onDisappear closure belonging to a Group, whose behaviour was subtly changed in Monterey. This is resolved by changing the Group to a VStack.

In addition, this PR fixes a crash occurring on Intel iGPU devices after stackotter/delta-client@dc81f1c2324d2b3b20cd2679f745198a703c93bc.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
