### PR TITLE
Update dependencies to fix security warnings (thanks to Dependabot's new SwiftPM support)

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -51,8 +51,8 @@
         "repositoryURL": "https://github.com/krzyzanowskim/CryptoSwift",
         "state": {
           "branch": null,
-          "revision": "eee9ad754926c40a0f7e73f152357d37b119b7fa",
-          "version": "1.7.1"
+          "revision": "32f641cf24fc7abc1c591a2025e9f2f572648b0f",
+          "version": "1.7.2"
         }
       },
       {
@@ -168,7 +168,7 @@
         "repositoryURL": "https://github.com/stackotter/swift-cross-ui",
         "state": {
           "branch": "main",
-          "revision": "3723584ac413dcddfcb490f3fa83d15b49f565f6",
+          "revision": "e4491a59449dec572c1d0d2c214f35825dbc34aa",
           "version": null
         }
       },

--- a/Sources/ClientGtk/ChatView.swift
+++ b/Sources/ClientGtk/ChatView.swift
@@ -1,7 +1,7 @@
 import SwiftCrossUI
 import DeltaCore
 
-class ChatViewState: ViewState {
+class ChatViewState: Observable {
   @Observed var error: String?
   @Observed var messages: [String] = []
   @Observed var message = ""
@@ -51,7 +51,7 @@ struct ChatView: View {
     ForEach(state.messages.reversed()) { message in
       Text(message)
     }
-    .frame(height: 200)
+    .frame(minHeight: 200)
     .padding(.top, 10)
   }
 }

--- a/Sources/ClientGtk/DeltaClientApp.swift
+++ b/Sources/ClientGtk/DeltaClientApp.swift
@@ -11,7 +11,7 @@ struct DeltaClientApp: App {
     case play(ServerDescriptor, ResourcePack)
   }
 
-  class StateStorage: AppState {
+  class StateStorage: Observable {
     @Observed var state = DeltaClientState.loading(message: "Loading")
   }
 

--- a/Sources/ClientGtk/GameView.swift
+++ b/Sources/ClientGtk/GameView.swift
@@ -2,7 +2,7 @@ import Dispatch
 import SwiftCrossUI
 import DeltaCore
 
-class GameViewState: ViewState {
+class GameViewState: Observable {
   enum State {
     case error(String)
     case connecting

--- a/Sources/ClientGtk/ServerSelectionView.swift
+++ b/Sources/ClientGtk/ServerSelectionView.swift
@@ -1,7 +1,7 @@
 import SwiftCrossUI
 import DeltaCore
 
-class ServerSelectionState: ViewState {
+class ServerSelectionState: Observable {
   @Observed var address = ""
   @Observed var error: String?
 }

--- a/Sources/Core/Package.resolved
+++ b/Sources/Core/Package.resolved
@@ -41,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/krzyzanowskim/CryptoSwift",
       "state" : {
-        "revision" : "19b3c3ceed117c5cc883517c4e658548315ba70b",
-        "version" : "1.6.0"
+        "revision" : "32f641cf24fc7abc1c591a2025e9f2f572648b0f",
+        "version" : "1.7.2"
       }
     },
     {
@@ -95,8 +95,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/OpenCombine/OpenCombine.git",
       "state" : {
-        "revision" : "9cf67e363738dbab61b47fb5eaed78d3db31e5ee",
-        "version" : "0.13.0"
+        "revision" : "8576f0d579b27020beccbccc3ea6844f3ddfc2c2",
+        "version" : "0.14.0"
       }
     },
     {
@@ -104,8 +104,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/sushichop/Puppy",
       "state" : {
-        "revision" : "9f3cf02dc92bc233e40ba8a66af20abb97978929",
-        "version" : "0.6.0"
+        "revision" : "b5af02a72a5a1f92a68e6eceee19cac804067ad9",
+        "version" : "0.7.0"
       }
     },
     {
@@ -122,8 +122,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-atomics.git",
       "state" : {
-        "revision" : "ff3d2212b6b093db7f177d0855adbc4ef9c5f036",
-        "version" : "1.0.3"
+        "revision" : "6c89474e62719ddcc1e9614989fff2f68208fe10",
+        "version" : "1.1.0"
       }
     },
     {
@@ -131,8 +131,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-case-paths",
       "state" : {
-        "revision" : "3c4eea896f8ee9cbe1c11d1d3d46b0f2809da958",
-        "version" : "0.12.0"
+        "revision" : "fc45e7b2cfece9dd80b5a45e6469ffe67fe67984",
+        "version" : "0.14.1"
       }
     },
     {
@@ -158,8 +158,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-log.git",
       "state" : {
-        "revision" : "6fe203dc33195667ce1759bf0182975e4653ba1c",
-        "version" : "1.4.4"
+        "revision" : "32e8d724467f8fe623624570367e3d50c5638e46",
+        "version" : "1.5.2"
       }
     },
     {
@@ -203,8 +203,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-parsing",
       "state" : {
-        "revision" : "4bb9192468c1a8be57f46b7d6fd4f561c88b2195",
-        "version" : "0.11.0"
+        "revision" : "27c941bbd22a4bbc53005a15a0440443fd892f70",
+        "version" : "0.12.1"
       }
     },
     {
@@ -266,8 +266,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/xctest-dynamic-overlay",
       "state" : {
-        "revision" : "62041e6016a30f56952f5d7d3f12a3fd7029e1cd",
-        "version" : "0.8.3"
+        "revision" : "4af50b38daf0037cfbab15514a241224c3f62f98",
+        "version" : "0.8.5"
       }
     },
     {


### PR DESCRIPTION
# Description

Just ran `swift package update` for both the root DeltaClient package and the nested DeltaCore package. To make sure the client still ran I had to update the DeltaClientGtk code for the most recent SwiftCrossUI API breaking changes.