### PR TITLE
Added sprinting when the user presses the forwards key twice within a short range of time

### DIFF
--- a/Sources/Core/Sources/ECS/Singles/InputState.swift
+++ b/Sources/Core/Sources/ECS/Singles/InputState.swift
@@ -94,6 +94,7 @@ public final class InputState: SingleComponent {
   /// Ticks the input state by flushing ``newlyPressed`` into ``keys`` and ``inputs``, and clearing
   /// ``newlyReleased``. Also emits events to the given ``EventBus``.
   func tick(_ isInputSuppressed: [Bool], _ eventBus: EventBus) {
+    /// increment the tick count
     tickCount += 1
     /// increment the time since the forwards key was pressed if it is currently pressed
     assert(isInputSuppressed.count == newlyPressed.count, "`isInputSuppressed` should be the same length as `newlyPressed`")
@@ -103,11 +104,14 @@ public final class InputState: SingleComponent {
       }
       ///test for forwards key
       if event.input == .moveForward {
+        /// if the forwards key has been pressed, released, and pressed again within 6 ticks, sprint
         if forwardsDownTime < forwardsUpTime && (forwardsDownTime + 6) > tickCount {
           inputs.insert(.sprint)
         } else {
+          /// if not then stop the user from sprinting
           inputs.remove(.sprint)
         }
+        /// reset the counts so the ints don't overflow
         tickCount = 0
         forwardsDownTime = 0
         forwardsUpTime = 0
@@ -125,7 +129,9 @@ public final class InputState: SingleComponent {
     }
 
     for event in newlyReleased {
+      ///test for forwards key being released
       if event.input == .moveForward {
+        /// if the forwards key has been released, set the time since it was released
         forwardsUpTime = tickCount
       }
       

--- a/Sources/Core/Sources/ECS/Singles/InputState.swift
+++ b/Sources/Core/Sources/ECS/Singles/InputState.swift
@@ -94,28 +94,20 @@ public final class InputState: SingleComponent {
   /// Ticks the input state by flushing ``newlyPressed`` into ``keys`` and ``inputs``, and clearing
   /// ``newlyReleased``. Also emits events to the given ``EventBus``.
   func tick(_ isInputSuppressed: [Bool], _ eventBus: EventBus) {
-    /// increment the tick count
+    // increment the tick count
     tickCount += 1
-    /// increment the time since the forwards key was pressed if it is currently pressed
+    // increment the time since the forwards key was pressed if it is currently pressed
     assert(isInputSuppressed.count == newlyPressed.count, "`isInputSuppressed` should be the same length as `newlyPressed`")
     for (var event, suppressInput) in zip(newlyPressed, isInputSuppressed) {
       if suppressInput {
         event.input = nil
       }
-      ///test for forwards key
+      // test for forwards key
       if event.input == .moveForward {
-        /// if the forwards key has been pressed, released, and pressed again within 6 ticks, sprint
-        if forwardsDownTime < forwardsUpTime && (forwardsDownTime + 6) > tickCount {
+        // if the forwards key has been released within 6 ticks, sprint
+        if (forwardsUpTime + 6) > tickCount {
           inputs.insert(.sprint)
-        } else {
-          /// if not then stop the user from sprinting
-          inputs.remove(.sprint)
         }
-        /// reset the counts so the ints don't overflow
-        tickCount = 0
-        forwardsDownTime = 0
-        forwardsUpTime = 0
-        forwardsDownTime = tickCount
       }
 
       eventBus.dispatch(event)
@@ -129,9 +121,11 @@ public final class InputState: SingleComponent {
     }
 
     for event in newlyReleased {
-      ///test for forwards key being released
+      // test for forwards key being released
       if event.input == .moveForward {
-        /// if the forwards key has been released, set the time since it was released
+        // if the forwards key has been released, stop sprinting
+        inputs.remove(.sprint)
+        // if the forwards key has been released, set the time since it was released
         forwardsUpTime = tickCount
       }
       

--- a/Sources/Core/Sources/ECS/Singles/InputState.swift
+++ b/Sources/Core/Sources/ECS/Singles/InputState.swift
@@ -24,6 +24,14 @@ public final class InputState: SingleComponent {
   /// The position of the right thumbstick.
   public private(set) var rightThumbstick: Vec2f = Vec2f(0, 0)
 
+  /// The time since the last time the player pressed the forwards key.
+  public private(set) var forwardsDownTime: Int = 0
+  /// The time since the last time the player released the forwards key.
+  public private(set) var forwardsUpTime: Int = 0
+  /// Counts the ticks
+  public private(set) var tickCount: Int = 0
+
+
   // MARK: Init
 
   /// Creates an empty input state.
@@ -86,10 +94,21 @@ public final class InputState: SingleComponent {
   /// Ticks the input state by flushing ``newlyPressed`` into ``keys`` and ``inputs``, and clearing
   /// ``newlyReleased``. Also emits events to the given ``EventBus``.
   func tick(_ isInputSuppressed: [Bool], _ eventBus: EventBus) {
+    tickCount += 1
+    /// increment the time since the forwards key was pressed if it is currently pressed
     assert(isInputSuppressed.count == newlyPressed.count, "`isInputSuppressed` should be the same length as `newlyPressed`")
     for (var event, suppressInput) in zip(newlyPressed, isInputSuppressed) {
       if suppressInput {
         event.input = nil
+      }
+      ///test for forwards key
+      if event.input == .moveForward {
+        if forwardsDownTime < forwardsUpTime && (forwardsDownTime + 6) > tickCount {
+          inputs.insert(.sprint)
+        } else {
+          inputs.remove(.sprint)
+        }
+        forwardsDownTime = tickCount
       }
 
       eventBus.dispatch(event)
@@ -103,6 +122,10 @@ public final class InputState: SingleComponent {
     }
 
     for event in newlyReleased {
+      if event.input == .moveForward {
+        forwardsUpTime = tickCount
+      }
+      
       // TODO: The release event of any inputs that were suppressed should probably also be suppressed
       eventBus.dispatch(event)
 

--- a/Sources/Core/Sources/ECS/Singles/InputState.swift
+++ b/Sources/Core/Sources/ECS/Singles/InputState.swift
@@ -26,7 +26,7 @@ public final class InputState: SingleComponent {
 
   /// The time since the last time the player pressed the forwards key.
   public private(set) var forwardsDownTime: Int = 0
-    /// Whether the spring was triggered by a double tap
+    /// Whether the sprint was triggered by a double tap
   public private(set) var sprintFromDoubleTap: Bool = false
   /// Counts the ticks
   public private(set) var tickCount: Int = 0
@@ -94,9 +94,8 @@ public final class InputState: SingleComponent {
   /// Ticks the input state by flushing ``newlyPressed`` into ``keys`` and ``inputs``, and clearing
   /// ``newlyReleased``. Also emits events to the given ``EventBus``.
   func tick(_ isInputSuppressed: [Bool], _ eventBus: EventBus) {
-    //Iincrement the tick count
+    // Increment the tick count
     tickCount += 1
-    // Increment the time since the forwards key was pressed if it is currently pressed
     assert(isInputSuppressed.count == newlyPressed.count, "`isInputSuppressed` should be the same length as `newlyPressed`")
     for (var event, suppressInput) in zip(newlyPressed, isInputSuppressed) {
       if suppressInput {
@@ -105,16 +104,19 @@ public final class InputState: SingleComponent {
       // Test for forwards key
       if event.input == .moveForward {
         if !inputs.contains(.moveForward) {
-          // If the forwards key has been released within 6 ticks, sprint
+          // If the forwards key has been pressed within 6 ticks, sprint
           if (forwardsDownTime + 6) >= tickCount {
             inputs.insert(.sprint)
           }
+          // The sprint comes from a double tap
           sprintFromDoubleTap = true
         }
+        // Update the forwards key down time
         forwardsDownTime = tickCount
       }
 
       if event.input == .sprint {
+        //If the user presses the sprint key then the sprint doesn't come from a double tap
         sprintFromDoubleTap = false
       }
 
@@ -132,6 +134,7 @@ public final class InputState: SingleComponent {
       // Test for forwards key being released
       if event.input == .moveForward {
         if sprintFromDoubleTap {
+          // Remove sprint if the forwards key is released and the sprint came from a double tap
           inputs.remove(.sprint)
         }
       }

--- a/Sources/Core/Sources/ECS/Singles/InputState.swift
+++ b/Sources/Core/Sources/ECS/Singles/InputState.swift
@@ -108,6 +108,9 @@ public final class InputState: SingleComponent {
         } else {
           inputs.remove(.sprint)
         }
+        tickCount = 0
+        forwardsDownTime = 0
+        forwardsUpTime = 0
         forwardsDownTime = tickCount
       }
 

--- a/Sources/Core/Sources/ECS/Singles/InputState.swift
+++ b/Sources/Core/Sources/ECS/Singles/InputState.swift
@@ -26,7 +26,7 @@ public final class InputState: SingleComponent {
 
   /// The time since the last time the player pressed the forwards key.
   public private(set) var forwardsDownTime: Int = 0
-    /// Whether the spring was triggerf by a double tap
+    /// Whether the spring was triggered by a double tap
   public private(set) var sprintFromDoubleTap: Bool = false
   /// Counts the ticks
   public private(set) var tickCount: Int = 0

--- a/Sources/Core/Sources/ECS/Singles/InputState.swift
+++ b/Sources/Core/Sources/ECS/Singles/InputState.swift
@@ -26,8 +26,8 @@ public final class InputState: SingleComponent {
 
   /// The time since the last time the player pressed the forwards key.
   public private(set) var forwardsDownTime: Int = 0
-  /// The time since the last time the player released the forwards key.
-  public private(set) var forwardsUpTime: Int = 0
+    /// Whether the spring was triggerf by a double tap
+  public private(set) var sprintFromDoubleTap: Bool = false
   /// Counts the ticks
   public private(set) var tickCount: Int = 0
 
@@ -94,20 +94,28 @@ public final class InputState: SingleComponent {
   /// Ticks the input state by flushing ``newlyPressed`` into ``keys`` and ``inputs``, and clearing
   /// ``newlyReleased``. Also emits events to the given ``EventBus``.
   func tick(_ isInputSuppressed: [Bool], _ eventBus: EventBus) {
-    // increment the tick count
+    //Iincrement the tick count
     tickCount += 1
-    // increment the time since the forwards key was pressed if it is currently pressed
+    // Increment the time since the forwards key was pressed if it is currently pressed
     assert(isInputSuppressed.count == newlyPressed.count, "`isInputSuppressed` should be the same length as `newlyPressed`")
     for (var event, suppressInput) in zip(newlyPressed, isInputSuppressed) {
       if suppressInput {
         event.input = nil
       }
-      // test for forwards key
+      // Test for forwards key
       if event.input == .moveForward {
-        // if the forwards key has been released within 6 ticks, sprint
-        if (forwardsUpTime + 6) > tickCount {
-          inputs.insert(.sprint)
+        if !inputs.contains(.moveForward) {
+          // If the forwards key has been released within 6 ticks, sprint
+          if (forwardsDownTime + 6) >= tickCount {
+            inputs.insert(.sprint)
+          }
+          sprintFromDoubleTap = true
         }
+        forwardsDownTime = tickCount
+      }
+
+      if event.input == .sprint {
+        sprintFromDoubleTap = false
       }
 
       eventBus.dispatch(event)
@@ -121,12 +129,11 @@ public final class InputState: SingleComponent {
     }
 
     for event in newlyReleased {
-      // test for forwards key being released
+      // Test for forwards key being released
       if event.input == .moveForward {
-        // if the forwards key has been released, stop sprinting
-        inputs.remove(.sprint)
-        // if the forwards key has been released, set the time since it was released
-        forwardsUpTime = tickCount
+        if sprintFromDoubleTap {
+          inputs.remove(.sprint)
+        }
       }
       
       // TODO: The release event of any inputs that were suppressed should probably also be suppressed


### PR DESCRIPTION
# Description

Added sprinting when the user presses the forwards key twice within a short range of time (6 ticks). 

Fixes issue #126 

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation comments
- [x] My changes generate no new warnings
