### PR TITLE
Make RenderCoordinator errors recoverable

### DIFF
--- a/Sources/Client/Views/Play/GameView.swift
+++ b/Sources/Client/Views/Play/GameView.swift
@@ -44,17 +44,17 @@ struct GameView: View {
   var body: some View {
     JoinServerAndThen(serverDescriptor, with: account) { client in
       WithRenderCoordinator(for: client) { renderCoordinator in
-        if let renderCoord = renderCoordinator {
+        if let renderCoordinator = renderCoordinator {
           VStack {
             switch state {
               case .playing:
                 ZStack {
                   WithController(controller, listening: $inputCaptured) {
                     if controllerOnly {
-                      gameView(client: client, renderCoordinator: renderCoord)
+                      gameView(client: client, renderCoordinator: renderCoordinator)
                     } else {
                       InputView(listening: $inputCaptured, cursorCaptured: !inGameMenuPresented && cursorCaptured) {
-                        gameView(client: client, renderCoordinator: renderCoord)
+                        gameView(client: client, renderCoordinator: renderCoordinator)
                       }
                       .onKeyPress { [weak client] key, characters in
                         client?.press(key, characters)
@@ -107,7 +107,7 @@ struct GameView: View {
               inputCaptured = false
             }
 
-            registerEventHandler(client, renderCoord)
+            registerEventHandler(client, renderCoordinator)
           }
         }
       } cancellationHandler: {

--- a/Sources/Client/Views/Play/GameView.swift
+++ b/Sources/Client/Views/Play/GameView.swift
@@ -44,71 +44,69 @@ struct GameView: View {
   var body: some View {
     JoinServerAndThen(serverDescriptor, with: account) { client in
       WithRenderCoordinator(for: client) { renderCoordinator in
-        if let renderCoordinator = renderCoordinator {
-          VStack {
-            switch state {
-              case .playing:
-                ZStack {
-                  WithController(controller, listening: $inputCaptured) {
-                    if controllerOnly {
+        VStack {
+          switch state {
+            case .playing:
+              ZStack {
+                WithController(controller, listening: $inputCaptured) {
+                  if controllerOnly {
+                    gameView(client: client, renderCoordinator: renderCoordinator)
+                  } else {
+                    InputView(listening: $inputCaptured, cursorCaptured: !inGameMenuPresented && cursorCaptured) {
                       gameView(client: client, renderCoordinator: renderCoordinator)
-                    } else {
-                      InputView(listening: $inputCaptured, cursorCaptured: !inGameMenuPresented && cursorCaptured) {
-                        gameView(client: client, renderCoordinator: renderCoordinator)
-                      }
-                      .onKeyPress { [weak client] key, characters in
-                        client?.press(key, characters)
-                      }
-                      .onKeyRelease { [weak client] key in
-                        client?.release(key)
-                      }
-                      .onMouseMove { [weak client] deltaX, deltaY in
-                        // TODO: Formalise this adjustment factor somewhere
-                        let sensitivityAdjustmentFactor: Float = 0.004
-                        let sensitivity = sensitivityAdjustmentFactor * managedConfig.mouseSensitivity
-                        client?.moveMouse(sensitivity * deltaX, sensitivity * deltaY)
-                      }
-                      .passthroughClicks(!cursorCaptured)
                     }
-                  }
-                  .onButtonPress { [weak client] button in
-                    guard let input = input(for: button) else {
-                      return
+                    .onKeyPress { [weak client] key, characters in
+                      client?.press(key, characters)
                     }
-                    client?.press(input)
-                  }
-                  .onButtonRelease { [weak client] button in
-                    guard let input = input(for: button) else {
-                      return
+                    .onKeyRelease { [weak client] key in
+                      client?.release(key)
                     }
-                    client?.release(input)
-                  }
-                  .onThumbstickMove { [weak client] thumbstick, x, y in
-                    switch thumbstick {
-                      case .left:
-                        client?.moveLeftThumbstick(x, y)
-                      case .right:
-                        client?.moveRightThumbstick(x, y)
+                    .onMouseMove { [weak client] deltaX, deltaY in
+                      // TODO: Formalise this adjustment factor somewhere
+                      let sensitivityAdjustmentFactor: Float = 0.004
+                      let sensitivity = sensitivityAdjustmentFactor * managedConfig.mouseSensitivity
+                      client?.moveMouse(sensitivity * deltaX, sensitivity * deltaY)
                     }
+                    .passthroughClicks(!cursorCaptured)
                   }
                 }
-              case .gpuFrameCaptureComplete(let file):
-                frameCaptureResult(file)
-                  .onAppear {
-                    cursorCaptured = false
-                    inputCaptured = false
+                .onButtonPress { [weak client] button in
+                  guard let input = input(for: button) else {
+                    return
                   }
-            }
+                  client?.press(input)
+                }
+                .onButtonRelease { [weak client] button in
+                  guard let input = input(for: button) else {
+                    return
+                  }
+                  client?.release(input)
+                }
+                .onThumbstickMove { [weak client] thumbstick, x, y in
+                  switch thumbstick {
+                    case .left:
+                      client?.moveLeftThumbstick(x, y)
+                    case .right:
+                      client?.moveRightThumbstick(x, y)
+                  }
+                }
+              }
+            case .gpuFrameCaptureComplete(let file):
+              frameCaptureResult(file)
+                .onAppear {
+                  cursorCaptured = false
+                  inputCaptured = false
+                }
           }
-          .onAppear {
-            modal.onError { [weak client] _ in
-              client?.game.tickScheduler.cancel()
-              cursorCaptured = false
-              inputCaptured = false
-            }
+        }
+        .onAppear {
+          modal.onError { [weak client] _ in
+            client?.game.tickScheduler.cancel()
+            cursorCaptured = false
+            inputCaptured = false
+          }
 
-            registerEventHandler(client, renderCoordinator)
-          }
+          registerEventHandler(client, renderCoordinator)
         }
       } cancellationHandler: {
         appState.update(to: .serverList)

--- a/Sources/Client/Views/Play/WithRenderCoordinator.swift
+++ b/Sources/Client/Views/Play/WithRenderCoordinator.swift
@@ -37,9 +37,11 @@ struct WithRenderCoordinator<Content: View>: View {
     .onAppear {
       do {
         try renderCoordinator = RenderCoordinator(client)
-      } catch let error as RendererError {
-        renderCoordinatorError = error
       } catch {
+        // The only errors thrown in the RenderCoordinator constructor are of type RendererError
+        if let rendererError = error as? RendererError {
+          renderCoordinatorError = rendererError
+        }
       }
     }
   }

--- a/Sources/Client/Views/Play/WithRenderCoordinator.swift
+++ b/Sources/Client/Views/Play/WithRenderCoordinator.swift
@@ -36,7 +36,7 @@ struct WithRenderCoordinator<Content: View>: View {
     }
     .onAppear {
       do {
-        try renderCoordinator = RenderCoordinator(client)
+        renderCoordinator = try RenderCoordinator(client)
       } catch let error as RendererError {
         renderCoordinatorError = error
       } catch {

--- a/Sources/Client/Views/Play/WithRenderCoordinator.swift
+++ b/Sources/Client/Views/Play/WithRenderCoordinator.swift
@@ -6,10 +6,10 @@ import DeltaRenderer
 /// without having to introduce additional loading states into views.
 struct WithRenderCoordinator<Content: View>: View {
   var client: Client
-  var content: (RenderCoordinator?) -> Content
+  var content: (RenderCoordinator) -> Content
   var cancel: () -> Void
 
-  init(for client: Client, @ViewBuilder content: @escaping (RenderCoordinator?) -> Content, cancellationHandler cancel: @escaping () -> Void) {
+  init(for client: Client, @ViewBuilder content: @escaping (RenderCoordinator) -> Content, cancellationHandler cancel: @escaping () -> Void) {
     self.client = client
     self.content = content
     self.cancel = cancel
@@ -40,7 +40,7 @@ struct WithRenderCoordinator<Content: View>: View {
       } catch let error as RendererError {
         renderCoordinatorError = error
       } catch {
-        renderCoordinatorError = RendererError(.unknown(error))
+        renderCoordinatorError = RendererError.unknown(error)
       }
     }
   }

--- a/Sources/Client/Views/Play/WithRenderCoordinator.swift
+++ b/Sources/Client/Views/Play/WithRenderCoordinator.swift
@@ -6,7 +6,7 @@ import DeltaRenderer
 /// without having to introduce additional loading states into views.
 struct WithRenderCoordinator<Content: View>: View {
   var client: Client
-  var content: (RenderCoordinator) -> Content
+  var content: (RenderCoordinator?) -> Content
   var cancel: () -> Void
 
   init(for client: Client, @ViewBuilder content: @escaping (RenderCoordinator?) -> Content, cancellationHandler cancel: @escaping () -> Void) {

--- a/Sources/Core/Renderer/RenderCoordinator.swift
+++ b/Sources/Core/Renderer/RenderCoordinator.swift
@@ -94,7 +94,7 @@ public final class RenderCoordinator: NSObject, MTKViewDelegate {
 
   /// The longest a frame has taken to encode so far.
   private var longestFrame: Double = 0
-  
+
   // MARK: Init
 
   /// Creates a render coordinator.

--- a/Sources/Core/Renderer/RenderCoordinator.swift
+++ b/Sources/Core/Renderer/RenderCoordinator.swift
@@ -24,9 +24,9 @@ public struct RendererError: LocalizedError {
         return "Failed to get metal device"
       case .makeRenderCommandQueue:
         return "Failed to make render command queue"
-      case.camera:
+      case .camera:
         return "Failed to create camera: \(String(describing: error!)) - \(error!.localizedDescription)"
-      case.skyBoxRenderer:
+      case .skyBoxRenderer:
         return "Failed to create sky box renderer: \(String(describing: error!)) - \(error!.localizedDescription)"
       case .worldRenderer:
         return "Failed to create world renderer: \(String(describing: error!)) - \(error!.localizedDescription)"

--- a/Sources/Core/Renderer/RenderCoordinator.swift
+++ b/Sources/Core/Renderer/RenderCoordinator.swift
@@ -3,23 +3,19 @@ import FirebladeMath
 import MetalKit
 import DeltaCore
 
-public struct RendererError: LocalizedError {
-  public enum ErrorKind {
-    case getMetalDevice
-    case makeRenderCommandQueue
-    case camera(Error)
-    case skyBoxRenderer(Error)
-    case worldRenderer(Error)
-    case guiRenderer(Error)
-    case screenRenderer(Error)
-    case depthState(Error)
-    case unknown(Error)
-  }
-  
-  public let kind: ErrorKind
+public enum RendererError: LocalizedError {
+  case getMetalDevice
+  case makeRenderCommandQueue
+  case camera(Error)
+  case skyBoxRenderer(Error)
+  case worldRenderer(Error)
+  case guiRenderer(Error)
+  case screenRenderer(Error)
+  case depthState(Error)
+  case unknown(Error)
   
   public var errorDescription: String? {
-    switch kind {
+    switch self {
       case .getMetalDevice:
         return "Failed to get metal device"
       case .makeRenderCommandQueue:
@@ -39,10 +35,6 @@ public struct RendererError: LocalizedError {
       case .unknown(let error):
         return "Failed with an unknown error \(error.labeledLocalizedDescription)"
     }
-  }
-  
-  public init(_ kind: ErrorKind) {
-    self.kind = kind
   }
 }
 
@@ -109,11 +101,11 @@ public final class RenderCoordinator: NSObject, MTKViewDelegate {
   /// - Parameter client: The client to render for.
   public required init(_ client: Client) throws {
     guard let device = MTLCreateSystemDefaultDevice() else {
-      throw RendererError(.getMetalDevice)
+      throw RendererError.getMetalDevice
     }
 
     guard let commandQueue = device.makeCommandQueue() else {
-      throw RendererError(.makeRenderCommandQueue)
+      throw RendererError.makeRenderCommandQueue
     }
 
     self.client = client
@@ -124,7 +116,7 @@ public final class RenderCoordinator: NSObject, MTKViewDelegate {
     do {
       camera = try Camera(device)
     } catch {
-      throw RendererError(.camera(error))
+      throw RendererError.camera(error)
     }
 
     do {
@@ -134,7 +126,7 @@ public final class RenderCoordinator: NSObject, MTKViewDelegate {
         commandQueue: commandQueue
       )
     } catch {
-      throw RendererError(.skyBoxRenderer(error))
+      throw RendererError.skyBoxRenderer(error)
     }
 
     do {
@@ -145,7 +137,7 @@ public final class RenderCoordinator: NSObject, MTKViewDelegate {
         profiler: profiler
       )
     } catch {
-      throw RendererError(.worldRenderer(error))
+      throw RendererError.worldRenderer(error)
     }
 
     do {
@@ -156,7 +148,7 @@ public final class RenderCoordinator: NSObject, MTKViewDelegate {
         profiler: profiler
       )
     } catch {
-      throw RendererError(.guiRenderer(error))
+      throw RendererError.guiRenderer(error)
     }
 
     do {
@@ -166,14 +158,14 @@ public final class RenderCoordinator: NSObject, MTKViewDelegate {
         profiler: profiler
       )
     } catch {
-      throw RendererError(.screenRenderer(error))
+      throw RendererError.screenRenderer(error)
     }
 
     // Create depth stencil state
     do {
       depthState = try MetalUtil.createDepthState(device: device)
     } catch {
-      throw RendererError(.depthState(error))
+      throw RendererError.depthState(error)
     }
 
     statistics = RenderStatistics(gpuCountersEnabled: false)

--- a/Sources/Core/Renderer/RenderCoordinator.swift
+++ b/Sources/Core/Renderer/RenderCoordinator.swift
@@ -102,7 +102,7 @@ public final class RenderCoordinator: NSObject, MTKViewDelegate {
   /// - Parameter client: The client to render for.
   public required init(_ client: Client) throws {
     guard let device = MTLCreateSystemDefaultDevice() else {
-      fatalError()
+      throw RendererError(kind: RendererError.ErrorKind.getMetalDevice)
     }
 
     guard let commandQueue = device.makeCommandQueue() else {


### PR DESCRIPTION
# Description

This pull request ensures that any errors that may surge in RenderCoordinator#init are propagated back to the UI and so that an error message is shown instead of crashing the entire client.

Fixes #175 (not sure if fully)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation comments
- [x] My changes generate no new warnings
